### PR TITLE
Add Docker support and Missing rc file error handling

### DIFF
--- a/.rcexample
+++ b/.rcexample
@@ -1,0 +1,8 @@
+{
+  "categories": {
+    "Food": ["RESTAURANT", "GROCERY", "FOOD"],
+    "Transport": ["UBER", "TAXI", "TRANSIT"],
+    "Bills": ["BILL", "INSURANCE", "UTILITIES"]
+  },
+  "excludes": []
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1
+
+## Dockerfile for [rbc-statement-parser](https://github.com/andrewscwei/rbc-statement-parser)
+
+ARG pythonVersion="3.12"
+
+# -- Base Stage
+
+FROM python:${pythonVersion}-slim AS base-stage
+
+ENV workDir="/app"
+ENV nonRootUser="notroot"
+ARG nonRootUID="1000"
+
+# Create input and output directories
+RUN mkdir -p ${workDir}/input ${workDir}/output
+
+# Set default locale to UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+# Prevent Python from writing .pyc files
+ENV PYTHONDONTWRITEBYTECODE=1
+# Enable Python tracebacks on segfaults
+ENV PYTHONFAULTHANDLER=1
+# Create the virtualenv inside project directory
+ENV PIPENV_VENV_IN_PROJECT=1
+
+# Create a non-root user
+RUN <<EOT
+  set -e
+  groupadd -g $nonRootUID $nonRootUser
+  useradd -m -u $nonRootUID -g $nonRootUID $nonRootUser
+EOT
+
+# -- Build Stage 
+
+FROM base-stage AS build-stage
+WORKDIR ${workDir}
+
+# Install and run `pipenv` to build Python dependencies
+RUN pip install --no-cache-dir pipenv
+COPY Pipfile Pipfile.lock ./
+RUN pipenv install --python $(which python3) -d
+
+# -- Run Stage
+
+FROM base-stage AS run-stage
+WORKDIR ${workDir}
+USER ${nonRootUser}
+
+# Set the Python path to use the virtualenv
+ENV PATH="${workDir}/.venv/bin:$PATH"
+
+# Copy built virtualenv and source code
+COPY --from=build-stage ${workDir}/.venv ${workDir}/.venv
+COPY --chown=${nonRootUser}:${nonRootUser} . .
+
+# Copy over .rc file if it exists. App will use default config if one is not found.
+COPY .rc* .
+
+# Set the entrypoint to run the Python script
+ENTRYPOINT ["python3", "main.py"]
+# Default to showing help/usage if no arguments provided
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -2,16 +2,6 @@
 
 Python script for parsing RBC PDF statements, compatible with both VISA and personal banking accounts (i.e. chequing, savings, etc). The output is a list of formatted transactions printed on console or output to a file.
 
-## Setup
-
-Set up environment:
-
-```sh
-$ pre-commit install
-$ pipenv install -d
-$ pipenv shell
-```
-
 ## Usage
 
 Download PDF statements from RBC and save them in a directory.
@@ -24,15 +14,62 @@ $ python main.py <pdf_file_or_dir_of_pdf_files>
 $ python main.py <pdf_file_or_dir_of_pdf_files> -o out.txt
 ```
 
-## Linting
+## Requirements
 
-```sh
-$ pylint **/*.py
+- **Python**
+  - Version number specified in `./python-version`)
+
+- **Python Pip packages**
+  - `pipenv`
+
+- **Optional**
+  - Docker
+  - pre-commit
+
+## Install
+
+### Quick Install
+
+In Terminal:
+
+```shell
+pipenv install --python $(which python3) -d
+pipenv shell
 ```
 
-## Config
+### Full Install
 
-Create a `.rc` file in project root. You can also provide another file name and pass it to `--config` or `-c` option flag when executing `main.py`. See below example to understand what this config does:
+```shell
+# Clone the repo
+git clone https://github.com/andrewscwei/rbc-statement-parser.git
+cd rbc-statement parser
+
+# Install pipenv if it doesn't exist
+if ! command -v pipenv >/dev/null 2>&1; then
+    echo "Installing pipenv..."
+    if command -v pipx >/dev/null 2>&1; then
+      pipx install --no-cache-dir pipenv
+    else
+      pip install --user pipenv
+    fi
+fi
+
+pipenv install --python $(which python3) -d
+pipenv shell
+
+python main.py /path/to/your/pdf-files
+```
+
+## Config File
+
+The parser will look for a `.rc` config file in the project root. If no file is found, the parser will use a default config.
+
+To create your own custom config, see `.rcexample` for a template.
+
+To provide a custom config file name or path, use the `--config` or `-c` option flag when executing `main.py`. 
+Example: `python main.py --config /path/to/myRcFile`
+
+### `.rc` file structure
 
 ```js
 {
@@ -67,4 +104,28 @@ Create a `.rc` file in project root. You can also provide another file name and 
     ...
   ]
 }
+```
+
+## Docker Usage
+
+This project can also be built and ran inside a Docker container:
+
+```shell
+cd rbc-statement-parser
+
+docker build -t rbc-parser .
+
+alias rbcparser='docker run --rm -v "$(pwd)":/app/input -v "$(pwd)":/app/output rbc-parser /app/input/ -o /app/output/output-$(date +"%s").txt'
+
+cd /path/to/your/rbc-pdf-files/
+
+# Parse all PDFs in current diretory into a output.txt file:
+rbcparser
+```
+
+## Linting
+
+```sh
+pre-commit install
+pylint **/*.py
 ```

--- a/main.py
+++ b/main.py
@@ -10,11 +10,31 @@ from app.visa import is_visa, parse_visa
 
 
 def parse_config(path: str) -> Config:
+    # Default configuration
+    default_config = {
+        "format": "{date}\t{method}\t{code}\t{description}\t{category}\t{amount}",
+        "categories": {},  # Empty dict instead of None
+        "excludes": []     # Empty list instead of None
+    }
+    
     try:
         with open(path, encoding="utf8") as json_file:
-            return json.load(json_file)
-    except Exception:
-        return {}
+            config = json.load(json_file)
+            # Merge with defaults, keeping user values where they exist
+            return {
+                "format": config.get("format", default_config["format"]),
+                "categories": config.get("categories", default_config["categories"]),
+                "excludes": config.get("excludes", default_config["excludes"])
+            }
+    except FileNotFoundError:
+        print(f"Warning: Config file '{path}' not found. Using default configuration.")
+        return default_config
+    except json.JSONDecodeError:
+        print(f"Warning: Config file '{path}' is not valid JSON. Using default configuration.")
+        return default_config
+    except Exception as e:
+        print(f"Warning: Error reading config file: {str(e)}. Using default configuration.")
+        return default_config
 
 
 def parse_files(path: str) -> list:
@@ -53,6 +73,10 @@ def parse_args() -> tuple[list, dict, str]:
 
 
 def parse_pdf(file_path: str, categories: dict, excludes: list) -> list:
+    # Ensure categories and excludes are never None
+    categories = categories or {}
+    excludes = excludes or []
+    
     if is_chequing(file_path):
         return parse_chequing(file_path, categories, excludes)
 


### PR DESCRIPTION
Hi @andrewscwei, thanks for creating this statement parser! It's just what I was looking for today for my own purposes.

I ran into a few small issues while setting up the repo, so I've created this Pull Request to make it a bit easier to setup the project on new machines.

Fixes:

- If `.rc` does not exist in the repo, the following error message is displayed:

```
❯ python main.py ~/git/kc/statements/personal-cheque
Traceback (most recent call last):
  File "/home/user/sync/git/kc/statements/parser/main.py", line 94, in <module>
    main()
  File "/home/user/sync/git/kc/statements/parser/main.py", line 71, in main
    for tx in parse_pdf(file, config.get("categories"), config.get("excludes"))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/sync/git/kc/statements/parser/main.py", line 57, in parse_pdf
    return parse_chequing(file_path, categories, excludes)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/sync/git/kc/statements/parser/app/chequing.py", line 142, in parse_chequing
    tx["category"] = match_category(tx.get("description"), categories)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/sync/git/kc/statements/parser/app/utils.py", line 47, in match_category
    for category in lookup:
                    ^^^^^^
TypeError: 'NoneType' object is not iterable
```

- I've added some error handling to `main.py` to use a simple default config if no `.rc` file is provided

- I've added a Dockerfile to be able to build and run the parser without needing to modify a user's system

- Updated the Readme to clarify the install process on a new machine

Thank you once again for creating this project!